### PR TITLE
Add option for alias in name instead of filename

### DIFF
--- a/src/dn.ts
+++ b/src/dn.ts
@@ -1,6 +1,6 @@
 import { App, Component, debounce, MarkdownRenderer, Menu, Modal, normalizePath, TAbstractFile, TFile, TFolder, WorkspaceLeaf } from 'obsidian';
 import { formatFileSize, formatFileSizeKBMB, getFolderStructure } from './utils/format';
-import { getPropsPerFile, getTagsPerFile } from './utils/tags';
+import { getPropsPerFile, getTagsPerFile, getFirstAliasPerFile } from './utils/tags';
 import { DNPieChart } from './utils/dnpiechart';
 import { DNTableManager } from './utils/dntablemanager';
 import { moment } from 'obsidian';
@@ -93,6 +93,7 @@ export class DNModal extends Modal {
 	previousX: number;
 	previousY: number;
 
+	use_alias = false;
 
 	constructor(app: App) {
 		super(app);
@@ -595,7 +596,7 @@ export class DNModal extends Modal {
 				tr.removeEventListener('mouseover', async (evt: MouseEvent) => { this.dnHandleHoverPreview(evt, file); });
 
 				const td1 = tr.createEl('td');
-				td1.createEl('a', { cls: this.dnSetFileIconClass(file.extension), text: file.name }).onClickEvent((evt: MouseEvent) => {
+				td1.createEl('a', { cls: this.dnSetFileIconClass(file.extension), text: this.dnGetFileName(file) }).onClickEvent((evt: MouseEvent) => {
 					if (leaf !== null && file !== null) {
 						this.dnOpenFileAlt(file, evt);
 					}
@@ -923,6 +924,13 @@ export class DNModal extends Modal {
 		return arrRecentFiles.sort((a, b) => b.stat.mtime - a.stat.mtime).slice(0, this.num_recent_files);
 	}
 
+	dnGetFileName(file: TFile): string {
+		if (this.use_alias) {
+			return getFirstAliasPerFile(file) || file.basename
+		}
+		return file.basename
+	}
+
 	async dnCreateRecentFiles(title: string, divF: HTMLDivElement, files: TFile[], num_files: number) {
 		if (files.length === 0) {
 			divF.createEl('h3', { cls: 'dn-subtitles', text: title });
@@ -941,7 +949,7 @@ export class DNModal extends Modal {
 
 				const aLink = divF.createEl('a', {
 					cls: this.dnSetFileIconClass(sfile.extension),
-					text: sfile.basename,
+					text: this.dnGetFileName(sfile),
 					title: sfile.path
 				});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ interface DNSettings {
 	hide_tags: boolean;
 	hide_frontmatter: boolean;
 	hide_columns: string[];
+	use_alias: boolean;
 }
 
 export const DEFAULT_SETTINGS: DNSettings = {
@@ -51,7 +52,8 @@ export const DEFAULT_SETTINGS: DNSettings = {
 	hide_date: false,
 	hide_tags: false,
 	hide_frontmatter: false,
-	hide_columns: []
+	hide_columns: [],
+	use_alias: true
 }
 
 export default class DNPlugin extends Plugin {
@@ -86,6 +88,7 @@ export default class DNPlugin extends Plugin {
 		this.DN_MODAL.color_other = this.settings.color_other;
 
 		this.DN_MODAL.hide_columns = this.dnSetHiddenColumns(this.settings.hide_columns);
+		this.DN_MODAL.use_alias = this.settings.use_alias;
 
 		this.addRibbonIcon('gauge', 'Open dashboard navigator', (evt: MouseEvent) => {
 			this.DN_MODAL.default_view = this.settings.default_view;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,6 +27,7 @@ export class DNSettingTab extends PluginSettingTab {
     toggleHideDateColumn: ToggleComponent;
     toggleHideTagsColumn: ToggleComponent;
     toggleHideFrontmatterColumn: ToggleComponent;
+    toggleUseFirstAliases: ToggleComponent;
 
     constructor(app: App, plugin: DNPlugin) {
         super(app, plugin);
@@ -645,5 +646,27 @@ export class DNSettingTab extends PluginSettingTab {
                 });
             });
 
+        new Setting(containerEl)
+            .setName('Use First Alias as Name')
+            .setDesc('Display the alias instead of the note name (similar to links)')
+            .addToggle((toggle) => {
+                this.toggleUseFirstAliases = toggle;
+                toggle
+                    .setValue(this.plugin.settings.use_alias)
+                    .onChange(async (val) => {
+                        this.plugin.settings.use_alias = val;
+                        this.plugin.DN_MODAL.use_alias = this.plugin.settings.use_alias;
+                        await this.plugin.saveSettings();
+                    })
+            }).addExtraButton((btn) => {
+                btn.setIcon('rotate-ccw');
+                btn.setTooltip('Restore default')
+                btn.onClick(() => {
+                    this.toggleUseFirstAliases.setValue(DEFAULT_SETTINGS.use_alias);
+                    this.plugin.settings.use_alias = DEFAULT_SETTINGS.use_alias;
+                    this.plugin.DN_MODAL.use_alias = this.plugin.settings.use_alias;
+                    this.plugin.saveSettings();
+                });
+            });
     }
 }

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -47,4 +47,9 @@ export function getPropsPerFile(file: TFile): string {
 	return fileProperties.join(' \n');
 }
 
+export function getFirstAliasPerFile(file: TFile): string | null {
+	const cache = this.app.metadataCache.getFileCache(file);
+	return cache?.frontmatter?.aliases?.[0]
+}
+
 


### PR DESCRIPTION
When using unique id for notes (e.g. with [Unique Note Creator](https://help.obsidian.md/Plugins/Unique+note+creator)), aliases are a more meaningful way to refer to notes.

This PR adds a way to use alternative names for notes using the function `dnGetFileName` (with fallback to basename), and a method `getFirstAliasPerFile` to get the alias from the font matter in a similar way that the tags are parsed.

In addition, there is a new setting options that changes whether or not the plugin uses the aliases for note name.